### PR TITLE
🚑 Add requirements.txt for `webapp up` hotfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# DO NOT REMOVE THIS FILE
+# Package dependencies are stored in environment.yml
+# This file is only here to allow "az webapp up" to run without errors.


### PR DESCRIPTION
Closes #42.

Adds a requirements.txt file containing only comments in order to allow the `az webapp up` command to run as instructed in the README.md. 