### PR TITLE
ENH: Add root endpoint for App Service health checks

### DIFF
--- a/Tests/test_api.py
+++ b/Tests/test_api.py
@@ -51,10 +51,10 @@ def assert_response_error_type(response: TestResponse, status_code: HTTP_STATUS_
     assert response.status_code == status_code.value
     response_json = response.json
 
-    # this makes mypy happy that a dictionary has actually been returned 
+    # this makes mypy happy that a dictionary has actually been returned
     assert response_json is not None
 
-    assert len(response_json['code']) > 0 
+    assert len(response_json['code']) > 0
     assert len(response_json['detail']) > 0
     assert response_json['status'] == status_code.value
     assert len(response_json['title']) > 0
@@ -62,6 +62,14 @@ def assert_response_error_type(response: TestResponse, status_code: HTTP_STATUS_
         assert response_json['extra_details'] == extra_details.value
     else:
         assert 'extra_details' not in response_json
+
+def test_health_check() -> None:
+    """
+    Test that the health check endpoint returns 200.
+    """
+    with app.test_client() as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_STATUS_CODE.OK.value
 
 
 def test_ping_unauthorized() -> None:

--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ def is_authenticated_request(req: Request) -> Optional[Response]:
 
 @inject
 @app.route("/", methods=['GET'])
-def health_check()-> Response:
+def health_check() -> Response:
     """
     Health check endpoint.
     :return: 200 OK.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,16 @@ def is_authenticated_request(req: Request) -> Optional[Response]:
     return None
 
 
+@inject
+@app.route("/", methods=['GET'])
+def health_check()-> Response:
+    """
+    Health check endpoint.
+    :return: 200 OK.
+    """
+    return make_response(jsonify({'status': 'Healthy'}), HTTP_STATUS_CODE.OK.value)
+
+
 @app.route("/v1/ping", methods=['GET'])
 def ping() -> Response:
     authentication_response = is_authenticated_request(request)


### PR DESCRIPTION
Closes #50 

Adds an endpoints to the "/" route which returns a 200 response if running, as well as a test for the endpoint.

Checked with manual set up including gateway + HTTPS listeners.